### PR TITLE
Fix browser compatibility issues of the zoom

### DIFF
--- a/remote/remotezoom.js
+++ b/remote/remotezoom.js
@@ -65,7 +65,7 @@ const RevealRemoteZoom = () => {
         console.warn('invalid focus parameter for applyZoom()'); return
       }
 
-      const transform = 'scale(200%) translate(' + (50 - focus.x) + '%, ' + (50 - focus.y) + '%)'
+      const transform = 'scale(2) translate(' + (50 - focus.x) + '%, ' + (50 - focus.y) + '%)'
 
       currentSlideElement.style.transform = transform
       currentZoom = focus


### PR DESCRIPTION
Chrome does not seem to like to value in percent, but Firefox and Chrome accept just the 2